### PR TITLE
Only generate editor VS configurations that match the current host platform

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Generator, List, Optional, Union, cast
 
 from misc.utility.color import print_error, print_info, print_warning
+from platform_methods import detect_arch
 
 # Get the "Godot" folder name ahead of time
 base_folder = Path(__file__).resolve().parent
@@ -1067,8 +1068,22 @@ def generate_vs_project(env, original_args, project_name="godot"):
     platform = env["platform"]
     target = env["target"]
     arch = env["arch"]
+    host_arch = detect_arch()
+
+    host_platform = "windows"
+    if (
+        sys.platform.startswith("linux")
+        or sys.platform.startswith("dragonfly")
+        or sys.platform.startswith("freebsd")
+        or sys.platform.startswith("netbsd")
+        or sys.platform.startswith("openbsd")
+    ):
+        host_platform = "linuxbsd"
+    elif sys.platform == "darwin":
+        host_platform = "macos"
 
     vs_configuration = {}
+    host_vs_configuration = {}
     common_build_prefix = []
     confs = []
     for x in sorted(glob.glob("platform/*")):
@@ -1097,6 +1112,12 @@ def generate_vs_project(env, original_args, project_name="godot"):
             if platform == platform_name:
                 common_build_prefix = msvs.get_build_prefix(env)
                 vs_configuration = vsconf
+            if platform_name == host_platform:
+                host_vs_configuration = vsconf
+                for a in vsconf["arches"]:
+                    if host_arch == a["architecture"]:
+                        host_arch = a["platform"]
+                        break
         except Exception:
             pass
 
@@ -1348,18 +1369,45 @@ def generate_vs_project(env, original_args, project_name="godot"):
     section2 = []
     for conf in confs:
         godot_platform = conf["platform"]
+        has_editor = "editor" in conf["targets"]
+
+        # Skip any platforms that can build the editor and don't match the host platform.
+        #
+        # When both Windows and Mac define an editor target, it's defined as platform+target+arch (windows+editor+x64 for example).
+        # VS only supports two attributes, a "Configuration" and a "Platform", and we currently map our target to the Configuration
+        # (i.e. editor/template_debug/template_release), and our architecture to the "Platform" (i.e. x64, arm64, etc).
+        # Those two are not enough to disambiguate multiple godot targets for different godot platforms with the same architecture,
+        # i.e. editor|x64 would currently match both windows editor intel 64 and linux editor intel 64.
+        #
+        # TODO: More work is needed in order to support generating VS projects that unambiguously support all platform+target+arch variations.
+        # The VS "Platform" has to be a known architecture that VS recognizes, so we can only play around with the "Configuration" part of the combo.
+        if has_editor and godot_platform != host_vs_configuration["platform"]:
+            continue
+
         for p in conf["arches"]:
             sln_plat = p["platform"]
             proj_plat = sln_plat
             godot_arch = p["architecture"]
 
-            # Redirect editor configurations for non-Windows platforms to the Windows one, so the solution has all the permutations
-            # and VS doesn't complain about missing project configurations.
+            # Redirect editor configurations for platforms that don't support the editor target to the default editor target on the
+            # active host platform, so the solution has all the permutations and VS doesn't complain about missing project configurations.
             # These configurations are disabled, so they show up but won't build.
-            if godot_platform != "windows":
+            if not has_editor:
                 section1 += [f"editor|{sln_plat} = editor|{proj_plat}"]
-                section2 += [
-                    f"{{{proj_uuid}}}.editor|{proj_plat}.ActiveCfg = editor|{proj_plat}",
+                section2 += [f"{{{proj_uuid}}}.editor|{proj_plat}.ActiveCfg = editor|{host_arch}"]
+
+                configurations += [
+                    f'<ProjectConfiguration Include="editor|{proj_plat}">',
+                    "  <Configuration>editor</Configuration>",
+                    f"  <Platform>{proj_plat}</Platform>",
+                    "</ProjectConfiguration>",
+                ]
+
+                properties += [
+                    f"<PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='editor|{proj_plat}'\">",
+                    "  <GodotConfiguration>editor</GodotConfiguration>",
+                    f"  <GodotPlatform>{proj_plat}</GodotPlatform>",
+                    "</PropertyGroup>",
                 ]
 
             for t in conf["targets"]:
@@ -1382,21 +1430,6 @@ def generate_vs_project(env, original_args, project_name="godot"):
                     f"  <GodotPlatform>{proj_plat}</GodotPlatform>",
                     "</PropertyGroup>",
                 ]
-
-                if godot_platform != "windows":
-                    configurations += [
-                        f'<ProjectConfiguration Include="editor|{proj_plat}">',
-                        "  <Configuration>editor</Configuration>",
-                        f"  <Platform>{proj_plat}</Platform>",
-                        "</ProjectConfiguration>",
-                    ]
-
-                    properties += [
-                        f"<PropertyGroup Condition=\"'$(Configuration)|$(Platform)'=='editor|{proj_plat}'\">",
-                        "  <GodotConfiguration>editor</GodotConfiguration>",
-                        f"  <GodotPlatform>{proj_plat}</GodotPlatform>",
-                        "</PropertyGroup>",
-                    ]
 
                 p = f"{project_name}.{godot_platform}.{godot_target}.{godot_arch}.generated.props"
                 imports += [


### PR DESCRIPTION
This fixes the issue of multiple duplicated editor configurations in the VS solution and project, when there's more than one `msvs.py` platform that declares an "editor" target. There's really no good way right now to support disambiguating VS configurations right now, because VS only supports a combination of "Configuration" and "Platform" strings. The "Platform" string must match an architecture (or generic platform codename) that VS is aware of (so can't be just any random name), which leaves us with the "Configuration" string to do all the work of combining the platform+target information that godot uses. Right now the "Configuration" string just encodes the godot target, which means a solution that includes linux and windows targets ends up with multiple identical "editor" + "x64" entries.

The Configuration strings that we're generating need to encode more info in order to support multiple platforms with identical arch names, so for now, this skips any platform that declares an "editor" target in msvs.py and doesn't match the current host platform, which is enough (for now) to bypass the issue - console platforms that are for example arm64 architectures which would technically trigger this problem actually have custom "Platform" names in VS, so they're not affected.